### PR TITLE
Updates to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-52 AS builder
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-70 AS builder
+
+USER root
+
+RUN yum install -y python36 && yum clean all
 
 WORKDIR /opt/app-root/src
+
+USER default
 
 COPY . .
 
 RUN npm install
 RUN npm run build
 
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-52
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-70
 
 COPY --from=builder /opt/app-root/src/dist dist
-COPY package.json .
+COPY package*.json ./
 RUN npm install --production
 
 ENV HOST=0.0.0.0 PORT=3000


### PR DESCRIPTION
- Bumps base image to ubi8/nodejs-12:1-70
- Installs python36 to resolve node-gyp error during build
- Copies the package.json and package-lock.json into the final image

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>